### PR TITLE
Do not advise to modify `yunohost_admin.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ disrupting their core function._
 We don't allow YunoHost packages to make changes to sensitive system files. So here are further customizations you can make to allow more monitoring:
 
 * Nginx:
-  * requests/connections: follow [these recommandations](https://github.com/firehol/netdata/tree/master/python.d#nginx) to enable `/stab_status`; for example by putting this `location` section in `/etc/nginx/conf.d/yunohost_admin.conf`:
+  * requests/connections: follow [these recommandations](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/nginx) to enable `/stab_status`; for example by creating the file `/etc/nginx/conf.d/default.d/netdat_stub.conf` with the following content:
 ```
+# For Netdata
 location /stub_status {
   stub_status on;
   # Security: Only allow access from the IP below.
@@ -36,7 +37,7 @@ location /stub_status {
   deny all;
  }
 ```
-  * weblogs: you can monitor all your nginx weblogs for errors; follow [these recommendations](https://github.com/firehol/netdata/tree/master/python.d#nginx_log)
+* weblogs: you can monitor all your nginx weblogs for errors; follow [these recommendations](https://github.com/firehol/netdata/tree/master/python.d#nginx_log)
 * phpfpm: follow [these recommandations](https://github.com/firehol/netdata/tree/master/python.d#phpfpm)
 * NetData registry: set the instance as its own NetData registry server to avoid leaking any information by default
 


### PR DESCRIPTION
Do not modify `yunohost_admin.conf` (diagnostic is always showing an error otherwise), instead create an extra file that is automatically imported.
Update the URL (is it the correct one?).

## Problem

- Diagnostic is always showing an error if `yunohost_admin.conf` was manually modified and the file is not automatically updated which is a security issue.

## Solution

- `yunohost_admin.conf` imports `.conf` files in the `/etc/nginx/conf.d/default.d/` folder, so it is better to create a file there.

## PR Status

- [x ] Code finished and ready to be reviewed/tested
- [x ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
