### PR TITLE
Upgrade to v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Shipped version:** 2.2.6~ynh1
+**Shipped version:** 2.3.0~ynh1
 
 **Demo:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Antifeatures

--- a/README_es.md
+++ b/README_es.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Versión actual:** 2.2.6~ynh1
+**Versión actual:** 2.3.0~ynh1
 
 **Demo:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Características no deseables

--- a/README_eu.md
+++ b/README_eu.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Paketatutako bertsioa:** 2.2.6~ynh1
+**Paketatutako bertsioa:** 2.3.0~ynh1
 
 **Demoa:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Ezaugarri zalantzagarriak

--- a/README_fr.md
+++ b/README_fr.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Version incluse :** 2.2.6~ynh1
+**Version incluse :** 2.3.0~ynh1
 
 **Démo :** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Anti-fonctionnalités

--- a/README_gl.md
+++ b/README_gl.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Versión proporcionada:** 2.2.6~ynh1
+**Versión proporcionada:** 2.3.0~ynh1
 
 **Demo:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Debes considerar

--- a/README_id.md
+++ b/README_id.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Versi terkirim:** 2.2.6~ynh1
+**Versi terkirim:** 2.3.0~ynh1
 
 **Demo:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Antifitur

--- a/README_nl.md
+++ b/README_nl.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Geleverde versie:** 2.2.6~ynh1
+**Geleverde versie:** 2.3.0~ynh1
 
 **Demo:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Anti-eigenschappen

--- a/README_pl.md
+++ b/README_pl.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Dostarczona wersja:** 2.2.6~ynh1
+**Dostarczona wersja:** 2.3.0~ynh1
 
 **Demo:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Niepożądane funkcje

--- a/README_ru.md
+++ b/README_ru.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**Поставляемая версия:** 2.2.6~ynh1
+**Поставляемая версия:** 2.3.0~ynh1
 
 **Демо-версия:** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: Анти-функции

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -28,7 +28,7 @@ _netdata is **fast** and **efficient**, designed to permanently run on all syste
 disrupting their core function._
 
 
-**分发版本：** 2.2.6~ynh1
+**分发版本：** 2.3.0~ynh1
 
 **演示：** <https://learn.netdata.cloud/docs/agent/demo-sites/>
 ## :red_circle: 负面特征

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "NetData"
 description.en = "Real-time performance and health monitoring"
 description.fr = "Monitoring serveur en temps reel"
 
-version = "2.2.6~ynh1"
+version = "2.3.0~ynh1"
 
 maintainers = ["JimboJoe"]
 
@@ -53,8 +53,8 @@ ram.runtime = "50M"
 
     [resources.sources]
     [resources.sources.main]
-    url = "https://github.com/netdata/netdata/releases/download/v2.2.6/netdata-v2.2.6.tar.gz"
-    sha256 = "bd98c146aa6d0c25f80cb50b1447b8aca8a17f0995b28a11a23e843b8f210f42"
+    url = "https://github.com/netdata/netdata/releases/download/v2.3.0/netdata-v2.3.0.tar.gz"
+    sha256 = "a5470c547f11deeb58ae6faf21e0b891997055ea293a626102be85e3ab7f011f"
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "^netdata-v([0-9.]*)tar.gz$"
     [resources.sources.go]


### PR DESCRIPTION
Upgrade sources
- `main` v2.3.0: https://github.com/netdata/netdata/releases/tag/v2.3.0

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
